### PR TITLE
fix: Limit API server access concurrency factor to 3 and set inference job frequency to daily

### DIFF
--- a/deployment/template-cronjob.yaml
+++ b/deployment/template-cronjob.yaml
@@ -151,7 +151,7 @@ parameters:
   displayName: Days for which report needs to be run
   required: true
   name: DAYS
-  value: "7"
+  value: "1"
 
 - description: "The CVE model type to use for inference, accepted values - bert/bert_torch/gru"
   displayName: CVE Model Name
@@ -181,7 +181,7 @@ parameters:
   displayName: Data Insert Concurrency
   required: true
   name: DATA_INSERT_CONCURRENCY
-  value: "5"
+  value: "3"
 
 - description: "CronJob scheduler value"
   displayName: CronJob scheduler value

--- a/deployment/template-job.yaml
+++ b/deployment/template-job.yaml
@@ -176,4 +176,4 @@ parameters:
   displayName: Data Insert Concurrency
   required: true
   name: DATA_INSERT_CONCURRENCY
-  value: "5"
+  value: "3"


### PR DESCRIPTION
As we are running inference daily, need to fetch data for 1 days only. Also reducing concurrent request and we have low RCU/WCU set in dynamodb. 